### PR TITLE
setup.sh now depends on libcapstone3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-from ubuntu:trusty
+from ubuntu:wily
 maintainer andrew@andrewdutcher.com
 
-run apt-get update &&									\
-	apt-get install -y virtualenvwrapper python2.7-dev build-essential libxml2-dev libxslt1-dev git libffi-dev cmake libreadline-dev libtool debootstrap debian-archive-keyring libglib2.0-dev libpixman-1-dev
+run apt-get update &&                                                                   \
+        apt-get install -y virtualenvwrapper python2.7-dev build-essential libxml2-dev libxslt1-dev git libffi-dev cmake libreadline-dev libtool debootstrap debian-archive-keyring libglib2.0-dev libpixman-1-dev libcapstone3
 
 run useradd -s /bin/bash -m angr
 


### PR DESCRIPTION
Trusty doesn't provide libcapstone3. Update to wily. apt-get install libcapstone3.