### PR TITLE
Make sure apt knows about i386 packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 from ubuntu:xenial
 maintainer yans@yancomm.net
 
+run dpkg --add-architecture i386
 run apt-get update &&									\
 	apt-get install -y virtualenvwrapper python2.7-dev build-essential libxml2-dev libxslt1-dev git libffi-dev cmake libreadline-dev libtool debootstrap debian-archive-keyring libglib2.0-dev libpixman-1-dev libqt4-dev graphviz-dev binutils-multiarch nasm libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386
 


### PR DESCRIPTION
We need to explicitly enable i386, as abb538 pulls in i386 packages. This fixes
docker build on amd64 and should be a no-op on i386 (only tested on amd64).