### PR TITLE
FIX: repos fail to clone

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,7 +30,7 @@ function usage
 DEBS=${DEBS-virtualenvwrapper python2.7-dev build-essential libxml2-dev libxslt1-dev git libffi-dev cmake libreadline-dev libtool debootstrap debian-archive-keyring libglib2.0-dev libpixman-1-dev libqt4-dev graphviz-dev binutils-multiarch nasm libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386}
 REPOS=${REPOS-ana idalink cooldict mulpyplexer capstone monkeyhex superstruct archinfo vex pyvex cle claripy simuvex angr angr-management angrop angr-doc binaries}
 
-ORIGIN_REMOTE=$(git remote -v | grep origin | head -n1 | awk '{print $2}' | sed -e "s|angr/angr-dev.*||" -e "s|github.com|git:@github.com|")
+ORIGIN_REMOTE=$(git remote -v | grep origin | head -n1 | awk '{print $2}' | sed -e "s|angr/angr-dev.*||")
 REMOTES=${REMOTES-${ORIGIN_REMOTE}angr ${ORIGIN_REMOTE}shellphish ${ORIGIN_REMOTE}mechaphish https://git:@github.com/zardus https://git:@github.com/rhelmot https://git:@github.com/salls}
 
 


### PR DESCRIPTION
Many repos fail to clone due to an incorrect string construction:
`[-] Trying to clone from git@git:@github.com:angr/archinfo`

This change fixes it on my end. Not sure what the second `-e` was supposed to do; as far as I can tell it simply shouldn't be there.

Someone with access to the members' private forks should verify that this doesn't break cloning those.