### PR TITLE
Revert "Update setup.sh"

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -202,7 +202,7 @@ then
 else
 	pip install virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
 	set +e
-	source /usr/local/bin/virtualenvwrapper.sh >>$OUTFILE 2>>$ERRFILE
+	source /etc/bash_completion.d/virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
 	set -e
 fi
 


### PR DESCRIPTION
Reverts angr/angr-dev#36

This broke installation on certain ubuntus, notably our CI. I suspect the location of this file depends on how you install virtualenvwrapper, through apt or pip. @dfraze, if you could re-do this but check for both locations I think that would be an acceptable solution.

```
[+] ~% ll /etc/bash_completion.d/virtualenvwrapper
-rw-r--r-- 1 root root 220 Oct  4  2014 /etc/bash_completion.d/virtualenvwrapper
[+] ~% ll /usr/local/bin/virtualenvwrapper.sh      rhelmot@violet [05:37:30 PM]
ls: cannot access '/usr/local/bin/virtualenvwrapper.sh': No such file or directory
```