### PR TITLE
Replace --no-use-wheel to --no-binary

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -400,7 +400,7 @@ then
     	done
 
 	info "Installing some other helpful stuff (logging to $OUTFILE)."
-	pip install -I --no-use-wheel keystone-engine >> $OUTFILE 2>> $ERRFILE # hack because keystone sucks
+	pip install -I --no-binary :all: keystone-engine >> $OUTFILE 2>> $ERRFILE # hack because keystone sucks
 	if pip install ipython pylint ipdb nose nose-timer coverage flaky sphinx sphinx_rtd_theme recommonmark 'requests[security]' >> $OUTFILE 2>> $ERRFILE
 	then
 		info "Success!"

--- a/setup.sh
+++ b/setup.sh
@@ -400,7 +400,7 @@ then
     	done
 
 	info "Installing some other helpful stuff (logging to $OUTFILE)."
-	pip install -I --no-binary :all: keystone-engine >> $OUTFILE 2>> $ERRFILE # hack because keystone sucks
+	pip install -I --no-binary=keystone-engine keystone-engine >> $OUTFILE 2>> $ERRFILE # hack because keystone sucks
 	if pip install ipython pylint ipdb nose nose-timer coverage flaky sphinx sphinx_rtd_theme recommonmark 'requests[security]' >> $OUTFILE 2>> $ERRFILE
 	then
 		info "Success!"


### PR DESCRIPTION
### Actual behaviour

**pip:7.0.0 (2015-05-21)**: `--no-use-wheel` and `--use-wheel` are deprecated in favour of new options `--no-binary` and `--only-binary`.

The beta release **pip:10.0.0b1 (2018-04-31)** do not have `--no-use-wheel` already:

```bash
$ ./setup.sh -p angr
[+] Enabling virtualenvwrapper.
[+] Creating pypy virtualenv angr...
Requirement already up-to-date: pip in /home/y0ngdi/.virtualenvs/angr/site-packages (10.0.0b1)
[+] Cloning angr components!
...
Successfully installed simuvex
Cleaning up...
[+] Installing some other helpful stuff (logging to /tmp/setup-1).

Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

no such option: --no-use-wheel
```

### What is the new behavior?

`--no-use-wheel` option has been replaced to `--no-binary`.