### PR TITLE
setup.sh: improve macOS compatibility

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR
@@ -203,7 +204,7 @@ then
 	source /usr/bin/virtualenvwrapper.sh >>$OUTFILE 2>>$ERRFILE
 	set -e
 else
-	pip install virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
+	python -m pip install virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
 	set +e
 	source /etc/bash_completion.d/virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
 	set -e


### PR DESCRIPTION
* macOS ships with a very old /bin/bash, which does not support
  "declare -A". Search bash in $PATH instead - this will pick up
  the newer version from Homebrew. Idea stolen from:
  https://stackoverflow.com/a/43948526/3832536

* pip binary might be missing, use "python -m pip" instead. This
  appears to be the recommended way to call pip anyway:
  https://bugs.python.org/issue22295