### PR TITLE
setup.sh: use python2 for building unicorn when possible

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -394,6 +394,12 @@ then
 		PIP_OPTIONS="$PIP_OPTIONS --find-links=$PWD/wheels"
 	fi
 
+	python2=$(which python2)
+	if [ $? -eq 0 ]
+	then
+		export UNICORN_QEMU_FLAGS="--python=$python2 $UNICORN_QEMU_FLAGS"
+	fi
+
 	# remove angr-management if running in pypy or in travis
 	#(python --version 2>&1| grep -q PyPy) && 
 	info "NOTE: removing angr-management until we sort out the pyside packaging"


### PR DESCRIPTION
See https://github.com/unicorn-engine/unicorn/issues/206

I got the same build failure as in this ticket, even though my default system python is python2. I think this is because virtualenv's default python must be python3?

In the ticket they mention that `$(which python2)` might not work on all systems - citing macOS - but it worked fine there for me. I added exit code check anyway, so that if python2 is not found, we revert to the old behavior.