### PR TITLE
Fix/pypy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ run apt-get update &&									\
 
 run useradd -s /bin/bash -m angr
 
+run su - angr -c "mkdir ~/bin && ln -s /usr/bin/pip3 ~/bin/pip && ln -s /usr/bin/python3 ~/bin/python"
+run su - angr -c "echo 'export PATH=~/bin:$PATH' >> /home/angr/.bashrc"
 run su - angr -c "git clone https://github.com/angr/angr-dev && cd angr-dev && ./setup.sh -w -e angr && ./setup.sh -w -p angr-pypy"
 run su - angr -c "echo 'workon angr' >> /home/angr/.bashrc"
 cmd su - angr

--- a/pypy_venv.sh
+++ b/pypy_venv.sh
@@ -46,7 +46,7 @@ fi
 
 # virtualenv
 set +e
-mkvirtualenv -p "$PWD/"pypy3-*/bin/pypy3 $NAME
+mkvirtualenv -p "$PWD/"pypy3*/bin/pypy3 $NAME
 set -e
 pip install -U setuptools
 


### PR DESCRIPTION
so, two things. 
First, there is no default pip after installed python3-pip, there is a pip3. And the default python is still python2. So I create a bin folder to hold symbolic link.
Second, now pypy package is called `pypy3.6` at present. so, here is the change.
