### PR TITLE
Update dependencies for arch

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -48,8 +48,8 @@ fi
 
 DEBS=${DEBS-virtualenvwrapper python3-pip python3-dev python3-setuptools build-essential libxml2-dev libxslt1-dev git libffi-dev cmake libreadline-dev libtool debootstrap debian-archive-keyring libglib2.0-dev libpixman-1-dev qtdeclarative5-dev binutils-multiarch nasm libssl-dev libc6:i386 libgcc1:i386 libstdc++6:i386 libtinfo5:i386 zlib1g:i386 openjdk-8-jdk}
 HOMEBREW_DEBS=${HOMEBREW_DEBS-python3 libxml2 libxslt libffi cmake libtool glib binutils nasm capstone unicorn}
-ARCHDEBS=${ARCHDEBS-python-virtualenvwrapper python3-pip libxml2 libxslt git libffi cmake readline libtool debootstrap glib2 pixman qt4 binutils binutils nasm lib32-glibc lib32-gcc-libs lib32-libstdc++5 lib32-zlib}
-ARCHCOMDEBS=${ARCHCOMDEBS-lib32-libtinfo}
+ARCHDEBS=${ARCHDEBS-python-virtualenvwrapper python-pip libxml2 libxslt git libffi cmake readline libtool debootstrap glib2 pixman qt4 binutils binutils nasm lib32-glibc lib32-gcc-libs lib32-zlib lib32-ncurses}
+ARCHCOMDEBS=${ARCHCOMDEBS}
 RPMS=${RPMS-gcc gcc-c++ make python3-virtualenvwrapper python3-pip python3-devel python3-setuptools libxml2-devel libxslt-devel git libffi-devel cmake readline-devel libtool debootstrap debian-keyring glib2-devel pixman-devel qt5-qtdeclarative-devel binutils-x86_64-linux-gnu nasm openssl-devel python2 glibc.i686 libgcc.i686 libstdc++.i686 ncurses-compat-libs.i686 zlib.i686 java-1.8.0-openjdk-devel}
 REPOS=${REPOS-idalink cooldict mulpyplexer monkeyhex superstruct archinfo vex pyvex cle claripy angr angr-management angrop angr-doc binaries ailment pysoot}
 declare -A EXTRA_DEPS


### PR DESCRIPTION
Updated the arch dependencies

1. `python3-pip` is just `python-pip`
2.  `lib32-ncurses` provides `/usr/lib32/libtinfo.so.6` instead of `lib32-libtinfo`
3. Whatever `lib32-libstdc++5` provided should be covered with `lib32-gcc-libs` according to https://github.com/flutter/flutter/issues/25035

I am pretty sure that 1 and 2 will break nothing, not sure what `lib32-libstdc++5` was needed for so that should probably be tested somewhat.