### PR TITLE
removed pacman confirmation request

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -241,7 +241,7 @@ fi
 info "Enabling virtualenvwrapper."
 if [ -e /etc/pacman.conf ]
 then
-	sudo pacman -S --needed python-virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
+	sudo pacman -S --needed --noconfirm python-virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
 	set +e
 	source /usr/bin/virtualenvwrapper.sh >>$OUTFILE 2>>$ERRFILE
 	set -e


### PR DESCRIPTION
Because the output of pacman is redirected, the user doesn't know that he should confirm the installation process. There is just a blank terminal and nothing happens.