### PR TITLE
Add support for NixOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 core
 */
 .gdb_history
+!admin/
 admin/setup.py
 admin/dist

--- a/setup.sh
+++ b/setup.sh
@@ -250,6 +250,11 @@ then
 	set +e
 	source /usr/bin/virtualenvwrapper-3.sh >>$OUTFILE 2>>$ERRFILE
 	set -e
+elif [ -e /etc/NIXOS ]
+then
+	set +e
+	source $(command -v virtualenvwrapper.sh) >>$OUTFILE 2>>$ERRFILE
+	set -e
 else
 	python3 -m pip install virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
 	set +e
@@ -453,7 +458,7 @@ then
 	then
 		python2=/usr/bin/python
 	else
-		python2=$(which python2)
+		python2=$(which python2 || echo)
 	fi
 	if [ ! -z "$python2" ]
 	then

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,38 @@
+with import <nixpkgs> { };
+
+let python_pkgs = py_pkgs: with py_pkgs; [
+  pip
+  setuptools
+];
+in
+  stdenv.mkDerivation rec {
+    name = "angr-env";
+
+    nativeBuildInputs = [ cmake pkgconfig git ];
+
+    buildInputs = [
+      bash
+      nasm
+      (python3.withPackages python_pkgs)
+      python2   # To build unicorn
+      python3Packages.virtualenvwrapper
+      libxml2
+      libxslt
+      libffi
+      readline
+      libtool
+      glib
+      debootstrap
+      pixman
+      qt5.qtdeclarative
+      openssl
+      jdk8
+
+    # needed for pure environments
+      which
+    ];
+
+    shellHook = ''
+      source $(command -v virtualenvwrapper.sh)
+    '';
+  }


### PR DESCRIPTION
This commit adds a shell.nix to allow Nix users to make a shell with all
dependencies installed. This also modifies the setup.sh in order to add
support for NixOS

I also used this oppurtunity to exemt the admin/ directory from the
gitignore (except for setup.py and dist)

There is still more work to do (angr has some test failures in NixOS because of the lack of a /lib/ld-linux.so) and pypy support is not included yet (I would need to patch the pypy ELFs) However, this works and most tests pass for a standard CPython env

I talked about this with @rhelmot a few days ago.