### PR TITLE
Add support for PyPy on NixOS

### DIFF
--- a/admin/bdist.py
+++ b/admin/bdist.py
@@ -202,7 +202,8 @@ else:
     DEFAULT_COPY_CMD = 'cp dist/* %s'
 
     COMMAND_BASE = """\
-#!/bin/bash -ex
+#!/usr/bin/env bash
+set -ex
 
 function python() {
     /opt/python/cp35-cp35m/bin/python "$@"

--- a/admin/bdist.sh
+++ b/admin/bdist.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -e
 
 INTERNAL_PYTHON=/opt/python/cp27-cp27mu/bin/python
@@ -18,8 +17,7 @@ mkdir -p $DEST
 shift
 
 cat > $DEST/build.sh <<EOF
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -e
 
 yum install -y libffi libffi-devel

--- a/admin/blame.sh
+++ b/admin/blame.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function blame()
 {

--- a/admin/releaser.sh
+++ b/admin/releaser.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 VERSION_MAJOR=8
 

--- a/admin/remotes.sh
+++ b/admin/remotes.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # on github
 GITHUB_REPOS="

--- a/extremely-simple-setup.sh
+++ b/extremely-simple-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$VIRTUAL_ENV" ]; then
   echo "Are you sure you want to install angr outside a python virtual environment?"

--- a/git_all.sh
+++ b/git_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function green
 {

--- a/pypy_venv.sh
+++ b/pypy_venv.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 NAME=$1
 DIR=$(dirname $0)
@@ -16,7 +17,17 @@ mkdir -p pypy
 cd pypy
 
 
-if [ -f "/etc/arch-release" ]; then
+if [ -f "/etc/NIXOS" ]; then
+    echo "This is NixOS, using pypy from nix-shell"
+
+    set +e
+    source $(command -v virtualenvwrapper.sh)
+    mkvirtualenv -p $(command -v pypy3) $NAME
+    set -e
+
+    echo "installed pypy in $NAME"
+    exit 0
+elif [ -f "/etc/arch-release" ]; then
     echo "This is an arch distro"
     ARCH=$(uname -m)
     SUBVERSION=$(pacman -Si pypy3 | grep "Version\s*:\s*[0-9.\-]*" | grep -o "[0-9.\-]*")

--- a/setup.sh
+++ b/setup.sh
@@ -231,6 +231,9 @@ then
 elif [ -e /etc/fedora-release ]
 then
 	[ $(rpm -q $RPMS  2>&1 | grep "is not installed" | wc -l) -ne 0 ] && error "Please install the following packages: $RPMS"
+elif [ -e /etc/NIXOS ]
+then
+	[ -z "$IN_NIX_SHELL" ] && error "Please run in the provided shell.nix"
 elif [ $IS_MACOS -eq 1 ]
 then
 	[ $(brew ls --versions $HOMEBREW_DEBS | wc -l) -ne $(echo $HOMEBREW_DEBS | wc -w) ] && error "Please install the following packages from homebrew: $HOMEBREW_DEBS"

--- a/shell.nix
+++ b/shell.nix
@@ -1,38 +1,33 @@
 with import <nixpkgs> { };
 
-let python_pkgs = py_pkgs: with py_pkgs; [
-  pip
-  setuptools
-];
-in
-  stdenv.mkDerivation rec {
-    name = "angr-env";
+stdenv.mkDerivation rec {
+  name = "angr-env";
 
-    nativeBuildInputs = [ cmake pkgconfig git ];
+  nativeBuildInputs = [ cmake pkgconfig git ];
 
-    buildInputs = [
-      bash
-      nasm
-      (python3.withPackages python_pkgs)
-      python2   # To build unicorn
-      python3Packages.virtualenvwrapper
-      libxml2
-      libxslt
-      libffi
-      readline
-      libtool
-      glib
-      debootstrap
-      pixman
-      qt5.qtdeclarative
-      openssl
-      jdk8
+  buildInputs = [
+    python3Packages.virtualenvwrapper
+    python2   # To build unicorn
+    python3   # For CPython install
+    pypy3     # for PyPy install
+    nasm
+    libxml2
+    libxslt
+    libffi
+    readline
+    libtool
+    glib
+    debootstrap
+    pixman
+    qt5.qtdeclarative
+    openssl
+    jdk8
 
     # needed for pure environments
-      which
-    ];
+    which
+  ];
 
-    shellHook = ''
+  shellHook = ''
       source $(command -v virtualenvwrapper.sh)
-    '';
-  }
+  '';
+}

--- a/tests/angr-test
+++ b/tests/angr-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Angr testing script

--- a/tests/shell.sh
+++ b/tests/shell.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # This is a convence script to help us debug travis failures.
 #

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 if [ "$1" == '-h' ]
 then

--- a/tests/travis-install.sh
+++ b/tests/travis-install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 echo "###"
 echo "### Cloning angr-dev..."

--- a/tests/travis-setup.sh
+++ b/tests/travis-setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 echo "###"
 echo "### Starting CI setup..."

--- a/tests/travis-test.sh
+++ b/tests/travis-test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/..


### PR DESCRIPTION
I hope you're ready to scream again, @rhelmot 

This makes a few modifications to shell scripts to make them use
/usr/bin/env instead of assuming /bin/bash exists, and also makes
setup.sh and pypy_venv.sh know more about NixOS (like getting mad at you
if you aren't in the perfectly good Nix shell I gave you).