### PR TITLE
Force skip for dependencies installation on NixOS

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -215,6 +215,9 @@ then
 			error "Your system doesn't have homebrew installed, I don't know how to install the dependencies.\nPlease install homebrew: https://brew.sh/\nOr install the equivalent of these homebrew packages: $HOMEBREW_DEBS."
 		fi
 		brew install $HOMEBREW_DEBS >>$OUTFILE 2>>$ERRFILE
+	elif [ -e /etc/NIXOS ]
+	then
+		info "Doing nothing about dependencies installation for NixOS, as they are provided via shell.nix..."
 	else
 		error "We don't know which dependencies to install for this sytem.\nPlease install the equivalents of these debian packages: $DEBS."
 	fi


### PR DESCRIPTION
As I was hitting the error "We don't know which dependencies to install for this sytem... when running `./setup.sh -i -p angr`.

Dependencies are handled by the `shell.nix` provided, and are checked later on in the script.