### PR TITLE
Don't use sudo when installing as root

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -183,31 +183,37 @@ trap 'error "An error occurred on line $LINENO. Saved output:"' ERR
 
 if [ "$INSTALL_REQS" -eq 1 ]
 then
+	if [ $EUID -eq 0 ]
+	then
+		export SUDO=
+	else
+		export SUDO=sudo
+	fi
 	if [ -e /etc/debian_version ]
 	then
 		if ! (dpkg --print-foreign-architectures | grep -q i386)
 		then
 			info "Adding i386 architectures..."
-			sudo dpkg --add-architecture i386 >>$OUTFILE 2>>$ERRFILE
-			sudo apt-get update >>$OUTFILE 2>>$ERRFILE
+			$SUDO dpkg --add-architecture i386 >>$OUTFILE 2>>$ERRFILE
+			$SUDO apt-get update >>$OUTFILE 2>>$ERRFILE
 		fi
 		info "Installing dependencies..."
-		sudo apt-get install -y $DEBS >>$OUTFILE 2>>$ERRFILE
+		$SUDO apt-get install -y $DEBS >>$OUTFILE 2>>$ERRFILE
 	elif [ -e /etc/pacman.conf ]
 	then
 		if ! grep --quiet "^\[multilib\]" /etc/pacman.conf;
 		then
 			info "Adding i386 architectures..."
-			sudo sed 's/^\(#\[multilib\]\)/\[multilib\]/' </etc/pacman.conf >/tmp/pacman.conf
-			sudo sed '/^\[multilib\]/{n;s/^#//}' </tmp/pacman.conf >/etc/pacman.conf
-			sudo pacman -Syu >>$OUTFILE 2>>$ERRFILE
+			$SUDO sed 's/^\(#\[multilib\]\)/\[multilib\]/' </etc/pacman.conf >/tmp/pacman.conf
+			$SUDO sed '/^\[multilib\]/{n;s/^#//}' </tmp/pacman.conf >/etc/pacman.conf
+			$SUDO pacman -Syu >>$OUTFILE 2>>$ERRFILE
 		fi
 		info "Installing dependencies..."
-		sudo pacman -S --noconfirm --needed $ARCHDEBS >>$OUTFILE 2>>$ERRFILE
+		$SUDO pacman -S --noconfirm --needed $ARCHDEBS >>$OUTFILE 2>>$ERRFILE
 	elif [ -e /etc/fedora-release ]
 	then
 		info "Installing dependencies..."
-		sudo dnf install -y $RPMS #>>$OUTFILE 2>>$ERRFILE
+		$SUDO dnf install -y $RPMS #>>$OUTFILE 2>>$ERRFILE
 	elif [ $IS_MACOS -eq 1 ]
 	then
 		if ! which brew > /dev/null;

--- a/setup.sh
+++ b/setup.sh
@@ -244,7 +244,6 @@ fi
 info "Enabling virtualenvwrapper."
 if [ -e /etc/pacman.conf ]
 then
-	sudo pacman -S --needed --noconfirm python-virtualenvwrapper >>$OUTFILE 2>>$ERRFILE
 	set +e
 	source /usr/bin/virtualenvwrapper.sh >>$OUTFILE 2>>$ERRFILE
 	set -e


### PR DESCRIPTION
This just removes the need to have sudo installed if running as root. On arch, we were also unconditionally installing virtualenvwrapper regardless if the user passed -i. Given that it was already being installed with -i, I removed it.