### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -229,7 +229,7 @@ fi
 info "Checking dependencies..."
 if [ -e /etc/debian_version ]
 then
-	[ $(dpkg --get-selections $DEBS | wc -l) -ne $(echo $DEBS | wc -w) ] && error "Please install the following packages: $DEBS"
+	[ $(dpkg --get-selections $DEBS | wc -l) -lt $(echo $DEBS | wc -w) ] && error "Please install the following packages: $DEBS"
 elif [ -e /etc/pacman.conf ]
 then
 	[ $(pacman -Qi $ARCHDEBS  2>&1 | grep "was not found" | wc -l) -ne 0 ] && error "Please install the following packages: $ARCHDEBS"


### PR DESCRIPTION
The output of `dpkg --get-selections` shows the package for both architectures if not specified further.
This leads to an error when comparing the `wc` results.
E.g.:
```
libssl-dev:amd64				install
libssl-dev:i386					install
```
Alternatively, we could specify `package`:`arch` specifically for each package.