### PR TITLE
Print error logs before exiting after failed clone attempt

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -359,7 +359,9 @@ function clone_repo
 
 	if [ ! -e $NAME ]
 	then
+		set +e
 		error "Failed to clone $NAME. Error was:"
+		set -e
 		cat $CLONE_LOG
 		rm -f $CLONE_LOG
 		return 1


### PR DESCRIPTION
Regarding https://github.com/angr/angr-dev/issues/83 in 
https://github.com/angr/angr-dev/blob/b065e60839442f2db6ab44c062da1987a0662cb2/setup.sh#L362

This PR makes the setup script print the error before exiting. 

