### PR TITLE
Temporarily pin pip to any version <20

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -320,7 +320,7 @@ then
 	workon $ANGR_VENV || error "Unable to activate the virtual environment."
 
 	# older versions of pip will fail to process the --find-links arg silently
-	pip3 install -U pip
+	pip3 install -U 'pip<20'
 fi
 
 function try_remote


### PR DESCRIPTION
There was an issue recently introduced with pip 20.0.1 that prevents
some binary wheels from being installed. This will result in failed
setup of angr-dev. Until it gets resolved, simply use a slightly older
version of pip.

More info: https://github.com/pypa/pip/issues/7629