### PR TITLE
Updating docker image to focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-from ubuntu:bionic
+from ubuntu:focal
 maintainer yans@yancomm.net
+
+arg DEBIAN_FRONTEND=noninteractive
 
 run dpkg --add-architecture i386
 run apt-get update &&									\


### PR DESCRIPTION
There's a new LTS so it would be good to have this image based on it.

I can confirm this builds. I'm not 100% sure what test failures are pre-existing unfortunately. Of note, focal defaults to python 3.8 now. I found and submitted a PR for a small issue:

https://github.com/angr/angr/pull/2112