### PR TITLE
Rewrite virtualenvwrapper activation logic

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: pools
   type: object
-  default: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
+  default: [ "ubuntu-18.04", "ubuntu-20.04", "windows-latest", "macos-latest" ]
 - name: python_versions
   type: object
   default: [ "3.6", "3.7", "3.8" ]


### PR DESCRIPTION
These changes should hopefully reduce the amount of distro-specific changes needed regarding virtualenvwrapper, as well as eliminate cases where two versions of virtualenvwrapper are installed simultaneously, causing issues. The idea is to try and use a preexisting version of virtualenvwrapper if installed, and if that fails, install from pip as a backup.

So far I haven't tested this on a variety of distros, I am going to attempt to do that before merging this in.