### PR TITLE
pypy pip setup tweak. closes #124

### DIFF
--- a/pypy_venv.sh
+++ b/pypy_venv.sh
@@ -90,7 +90,8 @@ fi
 
 # virtualenv
 set +e
-mkvirtualenv -p "$PWD/"pypy3.*/bin/pypy3 $NAME
+mkvirtualenv --no-pip -p "$PWD/"pypy3.*/bin/pypy3 $NAME
+python -m ensurepip
 set -e
 pip install -U setuptools
 

--- a/pypy_venv.sh
+++ b/pypy_venv.sh
@@ -93,7 +93,7 @@ set +e
 mkvirtualenv --no-pip -p "$PWD/"pypy3.*/bin/pypy3 $NAME
 python -m ensurepip
 set -e
-pip install -U setuptools
+python -m pip install -U setuptools
 
 echo "installed pypy in $NAME"
 exit 0


### PR DESCRIPTION
This workaround fixes the pypy issues when creating a new pypy env.

However, it appears there's at least one more issue, ref: https://github.com/zardus/mulpyplexer/issues/10

Until that is fixed, the docker will still not build and hasn't built for 3 months. If the fix for the mulpyplexer isn't simple, I'd recommend simply removing the pypy option from docker setup so that the image will at least build.