### PR TITLE
Adding check for conda default env

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -464,7 +464,7 @@ fi
 
 if [ $INSTALL -eq 1 ]
 then
-	if [ -z "$VIRTUAL_ENV" ] && [ $UNATTENDED != 1 ] && [ -z "$CONDA_DEFAULT_ENV" ]
+	if [ -z "$VIRTUAL_ENV" ] && [ -z "$CONDA_DEFAULT_ENV" ] && [ $UNATTENDED != 1 ]
 	then
 		warning "You are installing angr outside of a virtualenv. This is NOT"
 		warning "RECOMMENDED. Activate a virtualenv before running this script"

--- a/setup.sh
+++ b/setup.sh
@@ -464,7 +464,7 @@ fi
 
 if [ $INSTALL -eq 1 ]
 then
-	if [ -z "$VIRTUAL_ENV" ] && [ $UNATTENDED != 1 ]
+	if [ -z "$VIRTUAL_ENV" ] && [ $UNATTENDED != 1 ] && [ -z "$CONDA_DEFAULT_ENV" ]
 	then
 		warning "You are installing angr outside of a virtualenv. This is NOT"
 		warning "RECOMMENDED. Activate a virtualenv before running this script"


### PR DESCRIPTION
Installing into a conda env is basically the same as a python virtualenv. I don't think it's necessary to show a warning if that's the case.