### PR TITLE
Remove mulpyplexer and monkeyhex from default repo list in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -53,7 +53,7 @@ ARCHDEBS=${ARCHDEBS-python-pip libxml2 libxslt git libffi cmake readline libtool
 ARCHCOMDEBS=${ARCHCOMDEBS}
 RPMS=${RPMS-gcc gcc-c++ make python3-pip python3-devel python3-setuptools libxml2-devel libxslt-devel git libffi-devel cmake readline-devel libtool debootstrap debian-keyring glib2-devel pixman-devel qt5-qtdeclarative-devel binutils-x86_64-linux-gnu nasm openssl-devel python2 glibc.i686 libgcc.i686 libstdc++.i686 ncurses-compat-libs.i686 zlib.i686 java-1.8.0-openjdk-devel}
 OPENSUSE_RPMS=${OPENSUSE_RPMS-gcc gcc-c++ make python3-pip python3-devel python3-setuptools libxml2-devel libxslt-devel git libffi-devel cmake readline-devel libtool debootstrap glib2-devel libpixman-1-0-devel libQt5Core5 libqt5-qtdeclarative-devel binutils nasm libopenssl-devel python glibc-32bit libgcc_s1-32bit libstdc++6-32bit libncurses5-32bit libz1-32bit java-1_8_0-openjdk-devel} 
-REPOS=${REPOS-mulpyplexer monkeyhex archinfo vex pyvex cle claripy ailment angr angrop angr-doc binaries pysoot angr-targets}
+REPOS=${REPOS-archinfo vex pyvex cle claripy ailment angr angrop angr-doc binaries pysoot angr-targets}
 REPOS_CPYTHON=${REPOS_CPYTHON-angr-management}
 # archr is Linux only because of shellphish-qemu dependency
 if [ `uname` == "Linux" ]; then REPOS="${REPOS} archr"; fi


### PR DESCRIPTION
These repos aren't as tightly coupled with angr as the rest of the repos, I think we should leave these out by default.