### PR TITLE
Install repos with setup.cfg as well when performing concurrent clones

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -453,7 +453,7 @@ else
 		if wait ${CLONE_PROCS[$r]}
 		then
 			#echo "... SUCCESS"
-			[ -e "$r/setup.py" ] && TO_INSTALL="$TO_INSTALL $r"
+			[ -e "$r/setup.py" -o -e "$r/setup.cfg" ] && TO_INSTALL="$TO_INSTALL $r"
 		else
 			#echo "... FAIL"
 			exit 1


### PR DESCRIPTION
Currently, repositories with setup.cfg are not added to install list if the repositories are cloned concurrently. This PR fixes this by adding such repositories to the install list.