### PR TITLE
Add build_dev_wheels.sh script for snapshotting local environment into a distributable state

### DIFF
--- a/admin/build_dev_wheels.sh
+++ b/admin/build_dev_wheels.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+REPO_ROOT="$(realpath "$(dirname $0)/..")"
+
+# if you edit this or specify a new value make sure the packages are in dependency order!
+REPOS=${REPOS-archinfo pyvex claripy cle ailment angr}
+
+OUTDIR=${OUTDIR-./build}
+mkdir -p "$OUTDIR"
+
+python -m pip install -U setuptools wheel build
+export PIP_FIND_LINKS=$OUTDIR
+
+for REPO in $REPOS; do
+	python -m build --wheel --outdir "$OUTDIR" "$REPO_ROOT/$REPO"
+done
+
+echo 'All done!'
+echo "Wheels for $REPOS can be found in $OUTDIR"

--- a/admin/build_dev_wheels.sh
+++ b/admin/build_dev_wheels.sh
@@ -12,7 +12,7 @@ python -m pip install -U setuptools wheel build
 export PIP_FIND_LINKS=$OUTDIR
 
 for REPO in $REPOS; do
-	python -m build --wheel --outdir "$OUTDIR" "$REPO_ROOT/$REPO"
+	python -m build --outdir "$OUTDIR" "$REPO_ROOT/$REPO"
 done
 
 echo 'All done!'


### PR DESCRIPTION
This is, as far as I'm aware, the "correct" way to handle the new world of isolated builds, dev dependencies, and pep517.

As an example, if you have your angr-dev with a bunch of repos with maybe-uncommitted changes and you want to distribute this, you can run `./admin/build_dev_wheels.sh` and it will produce a folder named `build` which contains wheels for each of the core angr repos. You can then distribute this folder, and then `pip install angr==9.2.5.dev0 --find-links=./build` will work.