### PR TITLE
Add libz3 and libstdc++ to LD_LIBRARY_PATH in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     qt5.qtdeclarative
     openssl
     jdk8
+    pkgs.z3
 
     # needed for pure environments
     which
@@ -29,5 +30,6 @@ stdenv.mkDerivation rec {
 
   shellHook = ''
       source $(command -v virtualenvwrapper.sh)
+      export LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib:${pkgs.z3.lib}/lib:$LD_LIBRARY_PATH"
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -7,9 +7,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     python3Packages.virtualenvwrapper
-    python2   # To build unicorn
-    python3   # For CPython install
-    pypy3     # for PyPy install
+    python2 # To build unicorn
+    python3 # For CPython install
+    pypy3 # for PyPy install
     nasm
     libxml2
     libxslt
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   shellHook = ''
-      source $(command -v virtualenvwrapper.sh)
-      export LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib:${pkgs.z3.lib}/lib:$LD_LIBRARY_PATH"
+    source $(command -v virtualenvwrapper.sh)
+    export LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib:${pkgs.z3.lib}/lib:$LD_LIBRARY_PATH"
   '';
 }


### PR DESCRIPTION
Hi!

I was running into issues with the provided `shell.nix` when importing angr in
`ipython`.

`libz3.so` and `libstc++.so.6` weren't being found. Adding them to
`LD_LIBRARY_PATH` fixed the issue for me.

Not sure if this is worth merging since I haven't reproduced it on another
system, but I still thought it would be interesting to share here nevertheless.

I know that the virtual environment also holds a libz3.so, but I wasn't sure
how to reference the virtual environment path in the `shell.nix` if that's even
possible. So, I'm using the Z3 provided by nixpkgs instead.

Many thanks,
Paul

