### PR TITLE
Update documentation for docker installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you are working on macOS, you have to run the fix_macOS.sh script while in yo
 Alternatively, you can use the dockerfile:
 
 ```ShellSession
-$ docker build -t angr - < angr-dev/Dockerfile
+$ docker build -t angr angr-dev
 $ docker run -it angr
 ```
 


### PR DESCRIPTION
The current instruction for building the docker image, `docker build -t angr - < angr-dev/Dockerfile`, provides no build context. However, since 0e11fd09f3df3ce8605421df5b12457c9b426f38, the build context is required to include setup.sh.

This patch specifies an appropriate build context.