### PR TITLE
Do not use removed '-w' setup.sh parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ USER angr
 ADD --chown=angr . /home/angr/angr-dev
 WORKDIR /home/angr/angr-dev
 
-RUN ./setup.sh -w -e angr
+RUN ./setup.sh -e angr
 RUN echo 'source /usr/share/virtualenvwrapper/virtualenvwrapper.sh' >> /home/angr/.bashrc && \
     echo 'workon angr' >> /home/angr/.bashrc
 


### PR DESCRIPTION
edf579f984dae177aa70492e081184b2e26d460d removes the `-w` parameter from setup.sh but it is still referenced by the Dockerfile.

This patch removes the reference.