### PR TITLE
Specify builtins.Exception instead of Exception in pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -244,4 +244,4 @@ valid-classmethod-first-arg=cls
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
Pylint 3.0 will be removing support for specifying Exception without namespacing it as `builtins.Exception`. No functional change