### PR TITLE
Ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ core
 !.github/
 !.github/workflows
 !.github/ISSUE_TEMPLATE
-
+.env


### PR DESCRIPTION
This file is needed to make viscose work right but probably isn't something we want to keep in this repo.