### PR TITLE
Enable some previously disabled pylint rules

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -32,15 +32,11 @@ load-plugins=pylint.extensions.no_self_use,pylint.extensions.bad_builtin
 # it should appear only once).
 
 disable=
-    abstract-method,
     fixme,
     invalid-name,
-    len-as-condition,
     locally-disabled,
     missing-function-docstring,
     missing-module-docstring,
-    no-else-return,
-    protected-access,
     too-few-public-methods,
     too-many-ancestors,
     too-many-arguments,
@@ -53,8 +49,6 @@ disable=
     too-many-public-methods,
     too-many-return-statements,
     too-many-statements,
-    unidiomatic-typecheck,
-    consider-using-f-string,
 
 
 [REPORTS]


### PR DESCRIPTION
Justifications for each of these:
- `abstract-method`: This applies when an abstract method is not overridden in a child class but that class is not marked as being abstract itself. This seems like something we would want?
- `len-as-condition`: The argument is basically if you are only doing `len(thing)` as a condition, you should just use `thing` directly. Seems valid to me.
- `no-else-return`: Already covered by ruff
- `protected-access`: This one will probably show up a lot but this is something I believe we should actively be looking to correct when possible.
- `unidiomatic-typecheck`: Covered by ruff already in some repos, seems like a good rule.
- `consider-using-f-strong`: Covered by ruff already