### PR TITLE
get -P working on Arch (except angr-management)

### DIFF
--- a/pypy_venv.sh
+++ b/pypy_venv.sh
@@ -33,7 +33,7 @@ elif [ -f "/etc/arch-release" ]; then
     SUBVERSION=$(pacman -Si pypy3 | grep "Version\s*:\s*[0-9.\-]*" | grep -o "[0-9.\-]*")
     VERSION=${2-pypy3-$SUBVERSION-$ARCH}
     # get pypy
-    [ ! -e $VERSION.pkg.tar.zst ] && wget https://mirrors.kernel.org/archlinux/community/os/$ARCH/$VERSION.pkg.tar.zst
+    [ ! -e $VERSION.pkg.tar.zst ] && wget https://mirrors.kernel.org/archlinux/extra/os/$ARCH/$VERSION.pkg.tar.zst
     if [ ! -e $VERSION ]; then
         tar xf $VERSION.pkg.tar.zst
         mv ./opt/pypy3 ./$VERSION

--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,7 @@ REPOS_CPYTHON=${REPOS_CPYTHON-angr-management}
 if [ `uname` == "Linux" ]; then REPOS="${REPOS} archr"; fi
 declare -A EXTRA_DEPS
 EXTRA_DEPS["angr"]="sqlalchemy unicorn==2.0.1.post1"
-EXTRA_DEPS["pyvex"]="--pre capstone"
+EXTRA_DEPS["pyvex"]="--pre capstone scikit-build-core"
 
 ORIGIN_REMOTE=${ORIGIN_REMOTE-$(git remote -v | grep origin | head -n1 | awk '{print $2}' | sed -e "s|[^/:]*/angr-dev.*||")}
 REMOTES=${REMOTES-${ORIGIN_REMOTE}angr ${ORIGIN_REMOTE}shellphish ${ORIGIN_REMOTE}mechaphish https://git:@github.com/zardus https://git:@github.com/rhelmot https://git:@github.com/salls https://git:@github.com/lukas-dresel https://git:@github.com/mborgerson}


### PR DESCRIPTION
Update setup.sh following Arch consolidation of "community" repo into "extra" (as per https://archlinux.org/news/git-migration-announcement/), and specify new dependency `scikit-build-core`. This gets angr building under pypy on Arch. angr-management does not build since a PySide6 or shiboken6 version required by angr-management (!=6.7.0,>=6.4.2) does not currently build under pypy.